### PR TITLE
Bugfix: filter out nolynch before counting votes for player.

### DIFF
--- a/src/dao.js
+++ b/src/dao.js
@@ -751,6 +751,7 @@ module.exports = {
 		return module.exports.getPlayerByName(player)
 			.then((playerInstance) => {
 				return module.exports.getCurrentVotes(game, day)
+					.filter((vote) => vote.action !== module.exports.action.nolynch)
 					.filter((vote) => vote.target.id === playerInstance.id)
 					.then((votes) => votes.length);
 			});


### PR DESCRIPTION
Fixes errors resulting from the following conditions:
- One or more current `nolynch` actions exist on a certain day
- `getNumVotesForPlayer` is called for that day.

Problem is a result of attempting to access `target.id` on the target-less `nolynch` action(s).
