### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/SockDrawer/sockMafia.png?label=ready&title=Ready)](https://waffle.io/SockDrawer/sockMafia)
 [![Dependency Status](https://david-dm.org/yamikuronue/sockMafia/master.svg)](https://david-dm.org/yamikuronue/sockMafia/master)
 [![devDependency Status](https://david-dm.org/yamikuronue/sockMafia/master/dev-status.svg)](https://david-dm.org/yamikuronue/sockMafia/master#info=devDependencies)
 [![optionalDependency Status](https://david-dm.org/yamikuronue/sockMafia/master/optional-status.svg)](https://david-dm.org/yamikuronue/sockMafia/master#info=optionalDependencies)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/SockDrawer/sockMafia

This was requested by a real person (user yamikuronue) on waffle.io, we're not trying to spam you.
