### PR TITLE
fix: Phase end allows links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sockmafia",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Mafia plugin for sockbot",
   "main": "src/mafiabot.js",
   "scripts": {

--- a/src/templates/multiline/html/voteTemplate.handlebars
+++ b/src/templates/multiline/html/voteTemplate.handlebars
@@ -14,4 +14,4 @@
   </tr>
   </table>
   
-  With {{numPlayers}} playing, it's <b>{{toExecute}} to lynch!</b> {{#if showEndTime}}The phase will end {{endTime}}. {{/if}}
+  With {{numPlayers}} playing, it's <b>{{toExecute}} to lynch!</b> {{#if showEndTime}}The phase will end {{{endTime}}}. {{/if}}

--- a/src/templates/multiline/markdown/voteTemplate.handlebars
+++ b/src/templates/multiline/markdown/voteTemplate.handlebars
@@ -15,4 +15,4 @@
   </tr>
   </table>
   
-  With {{numPlayers}} playing, it's {{#bold}}{{toExecute}} to lynch!{{/bold}} {{#if showEndTime}}The phase will end {{endTime}}. {{/if}}
+  With {{numPlayers}} playing, it's {{#bold}}{{toExecute}} to lynch!{{/bold}} {{#if showEndTime}}The phase will end {{{endTime}}}. {{/if}}


### PR DESCRIPTION
This fixes the template so that links can be included in the "phase end" text that is echoed with each vote list. 